### PR TITLE
Added 6.2.2

### DIFF
--- a/scripts/buildall.sh
+++ b/scripts/buildall.sh
@@ -18,3 +18,4 @@ build 6.1.1
 build 6.1.2
 build 6.1.3
 build 6.1.4
+build 6.2.2


### PR DESCRIPTION
6.2.2 has a bug with the nested transform so I need to manually install it. I confirmed that changing the package.json to 6.2.2 works.